### PR TITLE
Fix error propagation in slice and map deserialization

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -212,7 +212,7 @@ func (vu *valueUnmapper) fromSliceValue(data *Value, v reflect.Value) error {
 		}
 		err := vu.fromValue(x, el)
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 
@@ -251,7 +251,7 @@ func (vu *valueUnmapper) fromMapValue(data *Value, v reflect.Value) error {
 		f := reflect.New(v.Type().Elem()).Elem()
 		err := vu.fromValue(x, f)
 		if err != nil {
-			return nil
+			return err
 		}
 		fmt.Println(key, f)
 		v.SetMapIndex(key, f)

--- a/deserialize_test.go
+++ b/deserialize_test.go
@@ -334,6 +334,76 @@ func fromValueTests() []fromValueTest {
 		err: `tahwil.Value: invalid value struct {}(struct {}{}) for kind "string"`,
 	})
 
+	// error inside a slice element should propagate
+	sliceTarget := &alltypesT{}
+	result = append(result, fromValueTest{
+		in: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 2,
+				Kind:  tahwil.Struct,
+				Value: map[string]*tahwil.Value{
+					"String": {Refid: 3, Kind: tahwil.String, Value: ""},
+					"Bool":   {Refid: 4, Kind: tahwil.Bool, Value: false},
+					"Int":    {Refid: 5, Kind: tahwil.Int, Value: int64(0)},
+					"Uint":   {Refid: 6, Kind: tahwil.Uint, Value: uint64(0)},
+					"Float":  {Refid: 7, Kind: tahwil.Float64, Value: 0.0},
+					"Pointer": {Refid: 8, Kind: tahwil.Ptr, Value: nil},
+					"Map":    {Refid: 9, Kind: tahwil.Map, Value: nil},
+					"Slice": {
+						Refid: 10,
+						Kind:  tahwil.Slice,
+						Value: []*tahwil.Value{
+							{
+								Refid: 11,
+								Kind:  tahwil.Int,
+								Value: "not-an-int", // wrong type: string instead of int
+							},
+						},
+					},
+				},
+			},
+		},
+		out: sliceTarget,
+		err: `tahwil.Value: invalid value string("not-an-int") for kind "int"`,
+	})
+
+	// error inside a map value should propagate
+	mapTarget := &alltypesT{}
+	result = append(result, fromValueTest{
+		in: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 2,
+				Kind:  tahwil.Struct,
+				Value: map[string]*tahwil.Value{
+					"String": {Refid: 3, Kind: tahwil.String, Value: ""},
+					"Bool":   {Refid: 4, Kind: tahwil.Bool, Value: false},
+					"Int":    {Refid: 5, Kind: tahwil.Int, Value: int64(0)},
+					"Uint":   {Refid: 6, Kind: tahwil.Uint, Value: uint64(0)},
+					"Float":  {Refid: 7, Kind: tahwil.Float64, Value: 0.0},
+					"Pointer": {Refid: 8, Kind: tahwil.Ptr, Value: nil},
+					"Slice":  {Refid: 9, Kind: tahwil.Slice, Value: nil},
+					"Map": {
+						Refid: 10,
+						Kind:  tahwil.Map,
+						Value: map[string]*tahwil.Value{
+							"key1": {
+								Refid: 11,
+								Kind:  tahwil.Int,
+								Value: "not-an-int", // wrong type: string instead of int
+							},
+						},
+					},
+				},
+			},
+		},
+		out: mapTarget,
+		err: `tahwil.Value: invalid value string("not-an-int") for kind "int"`,
+	})
+
 	return result
 }
 


### PR DESCRIPTION
`fromSliceValue` and `fromMapValue` both had a bug where errors from recursive `fromValue` calls were swallowed — they returned `nil` instead of the actual `err`. This meant that if deserialization of a child element failed (e.g. type mismatch), the caller would get no error back and silently end up with corrupt/zero data.

The fix is straightforward: `return nil` → `return err` in both places.

Added two test cases that exercise both paths by feeding a type-mismatched value inside a slice element and a map value respectively, and asserting the error surfaces.