### PR TITLE
Handle JSON struct tag options correctly

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -2,6 +2,7 @@ package tahwil
 
 import (
 	"reflect"
+	"strings"
 )
 
 type UnmapperError struct {
@@ -54,6 +55,9 @@ func (vu *valueUnmapper) fieldByTag(t reflect.Type, key string) string {
 	for i := 0; i < t.NumField(); i++ {
 		ft := t.Field(i)
 		k := ft.Tag.Get("json")
+		if k != "" {
+			k, _, _ = strings.Cut(k, ",")
+		}
 		if k == "" {
 			k = ft.Name
 		}

--- a/deserialize_test.go
+++ b/deserialize_test.go
@@ -222,6 +222,31 @@ func fromValueTests() []fromValueTest {
 		},
 	})
 
+	// json tags with options like omitempty should use only the name part
+	result = append(result, fromValueTest{
+		in: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 2,
+				Kind:  tahwil.Struct,
+				Value: map[string]*tahwil.Value{
+					"name": {
+						Refid: 3,
+						Kind:  tahwil.String,
+						Value: "test",
+					},
+					"value": {
+						Refid: 4,
+						Kind:  tahwil.Int,
+						Value: int64(42),
+					},
+				},
+			},
+		},
+		out: &omitemptyT{Name: "test", Value: 42},
+	})
+
 	p1 := &personT{
 		Name: "Martin",
 		Parent: &personT{

--- a/serialize.go
+++ b/serialize.go
@@ -3,6 +3,7 @@ package tahwil
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // An InvalidMapperKindError describes an invalid argument passed to ToValue.
@@ -78,6 +79,9 @@ func (vm *valueMapper) toValueMap(v reflect.Value) (result map[string]*Value, er
 		for i := 0; i < v.NumField(); i++ {
 			ft := v.Type().Field(i)
 			k := ft.Tag.Get("json")
+			if k != "" {
+				k, _, _ = strings.Cut(k, ",")
+			}
 			if k == "" {
 				k = ft.Name
 			}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -30,6 +30,11 @@ type interfaceST struct {
 	NoSerialize2 bool `json:"_"`
 }
 
+type omitemptyT struct {
+	Name  string `json:"name,omitempty"`
+	Value int    `json:"value,omitempty"`
+}
+
 type valueTest struct {
 	in  any
 	out *tahwil.Value
@@ -389,6 +394,31 @@ func valueTests() []valueTest {
 						Refid: 3,
 						Kind:  tahwil.Uint64,
 						Value: uint64(1),
+					},
+				},
+			},
+		},
+	})
+
+	// json tags with options like omitempty should use only the name part
+	result = append(result, valueTest{
+		in: &omitemptyT{Name: "test", Value: 42},
+		out: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 2,
+				Kind:  tahwil.Struct,
+				Value: map[string]*tahwil.Value{
+					"name": {
+						Refid: 3,
+						Kind:  tahwil.String,
+						Value: "test",
+					},
+					"value": {
+						Refid: 4,
+						Kind:  tahwil.Int,
+						Value: 42,
 					},
 				},
 			},


### PR DESCRIPTION
JSON struct tags can carry options after the name, e.g. `json:"name,omitempty"`. Both `toValueMap` (serialization) and `fieldByTag` (deserialization) were using the raw tag value as the field key, so a field tagged `json:"name,omitempty"` would serialize/deserialize with the literal key `"name,omitempty"` instead of `"name"`.

This meant any struct using `omitempty`, `string`, or other standard tag options would fail to round-trip correctly with `encoding/json`.

Fix: split the tag on `,` and use only the first part (`strings.Cut`), in both paths. Added test cases with `omitempty` tags for serialization and deserialization.