### PR TITLE
Introduce typed Kind constants

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -72,7 +72,7 @@ func (vu *valueUnmapper) fieldByTag(t reflect.Type, key string) string {
 
 func (vu *valueUnmapper) fromBoolValue(data *Value, v reflect.Value) error {
 	if v.Kind() != reflect.Bool {
-		return &InvalidUnmapperKindError{Expected: Bool, Kind: v.Kind().String()}
+		return &InvalidUnmapperKindError{Expected: string(Bool), Kind: v.Kind().String()}
 	}
 
 	if fval, ok := data.Value.(bool); ok {
@@ -227,7 +227,7 @@ func (vu *valueUnmapper) fromMapValue(data *Value, v reflect.Value) error {
 		return nil
 	}
 	if v.Kind() != reflect.Map {
-		return &InvalidUnmapperKindError{Expected: Map, Kind: v.Kind().String()}
+		return &InvalidUnmapperKindError{Expected: string(Map), Kind: v.Kind().String()}
 	}
 	var keys []reflect.Value
 	mi, ok := data.Value.(map[string]any)
@@ -286,7 +286,7 @@ func (vu *valueUnmapper) fromPtrValue(data *Value, v reflect.Value) error {
 
 func (vu *valueUnmapper) fromStringValue(data *Value, v reflect.Value) error {
 	if v.Kind() != reflect.String {
-		return &InvalidUnmapperKindError{Expected: String, Kind: v.Kind().String()}
+		return &InvalidUnmapperKindError{Expected: string(String), Kind: v.Kind().String()}
 	}
 
 	if fval, ok := data.Value.(string); ok {
@@ -305,7 +305,7 @@ func (vu *valueUnmapper) fromStructValue(data *Value, v reflect.Value) error {
 		v = v.Elem()
 	}
 	if v.Kind() != reflect.Struct {
-		return &InvalidUnmapperKindError{Expected: Struct, Kind: v.Kind().String()}
+		return &InvalidUnmapperKindError{Expected: string(Struct), Kind: v.Kind().String()}
 	}
 	var keys []reflect.Value
 	mi, ok := data.Value.(map[string]any)
@@ -387,7 +387,7 @@ func (vu *valueUnmapper) fromValue(data *Value, v reflect.Value) error {
 		return vu.fromRefValue(data, v)
 	}
 
-	return &InvalidUnmapperKindError{Kind: data.Kind}
+	return &InvalidUnmapperKindError{Kind: string(data.Kind)}
 }
 
 func FromValue(data *Value, v any) error {

--- a/deserialize_test.go
+++ b/deserialize_test.go
@@ -35,7 +35,7 @@ func fromValueTests() []fromValueTest {
 
 	str := "xxx"
 	alltypes := &alltypesT{
-		String:  tahwil.String,
+		String:  "string",
 		Slice:   []int{1, 2},
 		Map:     map[string]int{"1": 1, "2": 2},
 		Pointer: &str,
@@ -56,7 +56,7 @@ func fromValueTests() []fromValueTest {
 					"String": {
 						Refid: 3,
 						Kind:  tahwil.String,
-						Value: tahwil.String,
+						Value: "string",
 					},
 					"Slice": {
 						Refid: 4,

--- a/kinds.go
+++ b/kinds.go
@@ -1,29 +1,32 @@
 package tahwil
 
+// Kind represents the type kind stored in a Value.
+type Kind string
+
 const (
-	Ref = "ref"
+	Ref Kind = "ref"
 
-	Bool = "bool"
+	Bool Kind = "bool"
 
-	Int   = "int"
-	Int8  = "int8"
-	Int16 = "int16"
-	Int32 = "int32"
-	Int64 = "int64"
+	Int   Kind = "int"
+	Int8  Kind = "int8"
+	Int16 Kind = "int16"
+	Int32 Kind = "int32"
+	Int64 Kind = "int64"
 
-	Uint   = "uint"
-	Uint8  = "uint8"
-	Uint16 = "uint16"
-	Uint32 = "uint32"
-	Uint64 = "uint64"
+	Uint   Kind = "uint"
+	Uint8  Kind = "uint8"
+	Uint16 Kind = "uint16"
+	Uint32 Kind = "uint32"
+	Uint64 Kind = "uint64"
 
-	Float32 = "float32"
-	Float64 = "float64"
+	Float32 Kind = "float32"
+	Float64 Kind = "float64"
 
-	String = "string"
-	Struct = "struct"
-	Slice  = "slice"
-	Array  = "array"
-	Map    = "map"
-	Ptr    = "ptr"
+	String Kind = "string"
+	Struct Kind = "struct"
+	Slice  Kind = "slice"
+	Array  Kind = "array"
+	Map    Kind = "map"
+	Ptr    Kind = "ptr"
 )

--- a/reference.go
+++ b/reference.go
@@ -11,7 +11,7 @@ type Reference struct {
 
 type ResolverError struct {
 	Value *Value
-	Kind  string
+	Kind  Kind
 	Type  string
 }
 
@@ -147,11 +147,11 @@ func (r *Resolver) refFromValue(v *Value) (uint64, error) {
 	case uint64:
 		return vv, nil
 	default:
-		return 0, &ResolverError{Value: v, Kind: Ref, Type: Uint64}
+		return 0, &ResolverError{Value: v, Kind: Ref, Type: string(Uint64)}
 	}
 
 	if isSigned && signed < 0 {
-		return 0, &ResolverError{Value: v, Kind: Ref, Type: Uint64}
+		return 0, &ResolverError{Value: v, Kind: Ref, Type: string(Uint64)}
 	}
 	return uint64(signed), nil //nolint:gosec // bounds checked above
 }

--- a/serialize.go
+++ b/serialize.go
@@ -137,7 +137,7 @@ func (vm *valueMapper) sliceToValue(v reflect.Value, kind reflect.Kind) (result 
 	result = &Value{}
 
 	result.Refid = vm.nextRefid()
-	result.Kind = kind.String()
+	result.Kind = Kind(kind.String())
 	result.Value, err = vm.toValueSlice(v)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func (vm *valueMapper) mapOrStructToValue(v reflect.Value, kind reflect.Kind) (r
 	result = &Value{}
 
 	result.Refid = vm.nextRefid()
-	result.Kind = kind.String()
+	result.Kind = Kind(kind.String())
 	// not only maps can be set here, but also slices as they
 	// can be represented as a map[fieldName]value
 	result.Value, err = vm.toValueMap(v)
@@ -166,7 +166,7 @@ func (vm *valueMapper) scalarToValue(v reflect.Value) (result *Value, err error)
 
 	// here we process the remaining kinds ("simple" ones)
 	result.Refid = vm.nextRefid()
-	result.Kind = v.Type().Name()
+	result.Kind = Kind(v.Type().Name())
 	if result.Kind == "" {
 		return nil, &InvalidMapperKindError{Kind: ""}
 	}

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -432,7 +432,7 @@ func valueTests() []valueTest {
 
 	result = append(result, valueTest{
 		in:  [4]int{1, 2, 3, 4},
-		err: &tahwil.InvalidMapperKindError{Kind: tahwil.Array},
+		err: &tahwil.InvalidMapperKindError{Kind: string(tahwil.Array)},
 	})
 
 	result = append(result, valueTest{

--- a/value_test.go
+++ b/value_test.go
@@ -502,7 +502,7 @@ func TestValue_UnmarshalJSON(t *testing.T) {
 
 func TestInvalidValueKindError_Error(t *testing.T) {
 	err := &tahwil.InvalidValueKindError{Kind: "invalid"}
-	expected := "tahwil.Value: invalid value kind \"" + err.Kind + "\""
+	expected := "tahwil.Value: invalid value kind \"" + string(err.Kind) + "\""
 	if err.Error() != expected {
 		t.Errorf("mismatch\nhave: %#+v\nwant: %#+v", err.Error(), expected)
 	}


### PR DESCRIPTION
## Summary

- Define `type Kind string` so that kind identifiers (`Ref`, `Bool`, `Int`, …) are
  no longer plain `string` values. This lets the compiler reject accidental misuse —
  for instance passing a raw `reflect.Kind.String()` where a `Kind` is expected, or
  comparing a `Kind` against an arbitrary string without an explicit conversion.
- Update `Value.Kind`, `InvalidValueError.Kind`, `InvalidValueKindError.Kind`, and
  `ResolverError.Kind` to use the new type.
- Add explicit `Kind(…)` / `string(…)` conversions at the boundaries: JSON
  unmarshaling, `reflect.Kind` stringification, and error structs whose fields
  intentionally remain `string` (`InvalidMapperKindError`, `InvalidUnmapperKindError`).

## Test plan

- [x] All existing unit tests pass (`go test -race ./... -v`)
- [x] No gopls diagnostics after changes
- [ ] CI lint + test pipeline passes