### PR TITLE
Avoid fmt.Sprintf for string map keys

### DIFF
--- a/serialize.go
+++ b/serialize.go
@@ -66,7 +66,12 @@ func (vm *valueMapper) toValueMap(v reflect.Value) (result map[string]*Value, er
 		for _, idx := range keys {
 			i := idx.Interface()
 			val := v.MapIndex(idx)
-			resIdx := fmt.Sprintf("%v", i)
+			var resIdx string
+			if s, ok := i.(string); ok {
+				resIdx = s
+			} else {
+				resIdx = fmt.Sprintf("%v", i)
+			}
 			result[resIdx], err = vm.toValue(val)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
## Summary

- In `toValueMap`, map keys are converted to strings via `fmt.Sprintf("%v", i)`.
  For the overwhelmingly common case — maps with `string` keys — this is
  unnecessary overhead: each call allocates a temporary buffer and invokes the
  full `fmt` formatting machinery.
- Add a fast path that type-asserts the key to `string` first, falling back to
  `fmt.Sprintf` only for non-string key types (e.g. `int`, `float64`).

## Test plan

- [x] All existing unit tests pass (`go test -race ./... -v`)
- [x] CI lint + test pipeline passes