### PR TITLE
Add Unwrap() support to UnmapperError

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -6,11 +6,19 @@ import (
 )
 
 type UnmapperError struct {
-	text string
+	text  string
+	cause error
 }
 
 func (e *UnmapperError) Error() string {
+	if e.cause != nil {
+		return "tahwil.FromValue: " + e.cause.Error()
+	}
 	return "tahwil.FromValue: " + e.text
+}
+
+func (e *UnmapperError) Unwrap() error {
+	return e.cause
 }
 
 // An InvalidUnmapperKindError describes an invalid argument passed to FromValue.
@@ -401,7 +409,7 @@ func FromValue(data *Value, v any) error {
 	resolver := NewResolver(data)
 	vu := newValueUnmapper()
 	if err := resolver.Resolve(); err != nil {
-		return &UnmapperError{text: err.Error()}
+		return &UnmapperError{cause: err}
 	}
 	if resolver.HasUnresolved() {
 		return &UnmapperError{text: "can't resolve all refs, invalid input"}


### PR DESCRIPTION
`UnmapperError` was converting wrapped errors to plain strings via
`err.Error()`, which broke the error chain. Callers couldn't use
`errors.Is` or `errors.As` to inspect the underlying cause (e.g. to
check if a `ResolverError` was behind a `FromValue` failure).

## Changes

- Add a `cause error` field to `UnmapperError` alongside the existing
  `text` field (plain-string errors like "value must be non-nil Pointer"
  still use `text`)
- Add `Unwrap() error` method so the standard library error inspection
  works through the chain
- Update `FromValue` to store the resolver error directly instead of
  flattening it to a string
- `Error()` output is unchanged — existing string comparisons in callers
  won't break

## Test plan

- [x] New `TestUnmapperError_Unwrap` verifies `errors.As` can reach
  `*ResolverError` through `*UnmapperError`
- [x] All existing tests pass (`go test -race ./...`)