### PR TITLE
Add array support

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -198,6 +198,12 @@ func (vu *valueUnmapper) fromFloatValue(data *Value, v reflect.Value) error {
 }
 
 func (vu *valueUnmapper) fromArrayValue(data *Value, v reflect.Value) error {
+	if v.Kind() == reflect.Interface {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Array {
+		return &InvalidUnmapperKindError{Expected: "array", Kind: v.Kind().String()}
+	}
 	if data.Value == nil {
 		return nil
 	}

--- a/deserialize_test.go
+++ b/deserialize_test.go
@@ -276,6 +276,25 @@ func fromValueTests() []fromValueTest {
 		},
 	})
 
+	// array deserialization
+	arr := &[3]int{10, 20, 30}
+	result = append(result, fromValueTest{
+		in: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 2,
+				Kind:  tahwil.Array,
+				Value: []*tahwil.Value{
+					{Refid: 3, Kind: tahwil.Int, Value: int64(10)},
+					{Refid: 4, Kind: tahwil.Int, Value: int64(20)},
+					{Refid: 5, Kind: tahwil.Int, Value: int64(30)},
+				},
+			},
+		},
+		out: arr,
+	})
+
 	p1 := &personT{
 		Name: "Martin",
 		Parent: &personT{

--- a/serialize.go
+++ b/serialize.go
@@ -219,13 +219,11 @@ func (vm *valueMapper) toValue(v reflect.Value) (result *Value, err error) {
 	}
 
 	switch kind {
-	case reflect.Chan, reflect.Func, reflect.Uintptr, reflect.Array, reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.Uintptr, reflect.UnsafePointer:
 		return nil, &InvalidMapperKindError{Kind: kind.String()}
 	case reflect.Ptr:
 		return vm.ptrToValue(v)
-	// case reflect.Array: // TODO: implement array?
-	//	fallthrough
-	case reflect.Slice:
+	case reflect.Array, reflect.Slice:
 		return vm.sliceToValue(v, kind)
 	case reflect.Struct, reflect.Map:
 		return vm.mapOrStructToValue(v, kind)
@@ -245,7 +243,7 @@ func (vm *valueMapper) toValue(v reflect.Value) (result *Value, err error) {
 //     produce a further *Value that will be stored in (*Value).Value.
 //   - the transformation process will continue until all the non-simple types are processed.
 //   - non-serializable types (func, chan) will lead to a mapping error.
-//   - there are unsupported serializable types: array, complex[64,128], unsafe pointer.
+//   - there are unsupported serializable types: complex[64,128], unsafe pointer.
 //   - ptr type will produce *Value with an underlying value.
 //   - nil ptr will result in (*Value).Value set to nil.
 //   - each non-nil pointer Refid is stored in a Refid map. This map is used

--- a/serialize_test.go
+++ b/serialize_test.go
@@ -468,8 +468,20 @@ func valueTests() []valueTest {
 	})
 
 	result = append(result, valueTest{
-		in:  [4]int{1, 2, 3, 4},
-		err: &tahwil.InvalidMapperKindError{Kind: string(tahwil.Array)},
+		in: &[3]int{10, 20, 30},
+		out: &tahwil.Value{
+			Refid: 1,
+			Kind:  tahwil.Ptr,
+			Value: &tahwil.Value{
+				Refid: 0,
+				Kind:  tahwil.Array,
+				Value: []*tahwil.Value{
+					{Refid: 0, Kind: tahwil.Int, Value: 10},
+					{Refid: 0, Kind: tahwil.Int, Value: 20},
+					{Refid: 0, Kind: tahwil.Int, Value: 30},
+				},
+			},
+		},
 	})
 
 	result = append(result, valueTest{

--- a/value.go
+++ b/value.go
@@ -114,7 +114,7 @@ func fixTypes(kind Kind, v any) (res any, err error) {
 		return fixPtr(kind, v)
 	case Struct, Map:
 		return fixStructOrMap(kind, v)
-	case /*Array, */ Slice: // TODO: support array?
+	case Array, Slice:
 		return fixSlice(kind, v)
 	}
 


### PR DESCRIPTION
Arrays (`[N]T`) were explicitly rejected in `toValue` and had TODO comments
scattered across the codebase. Since arrays share the same reflection API
as slices (`Len()`, `Index()`), adding support is straightforward.

Closes #2

## Changes

- **Serialization**: `reflect.Array` now handled alongside `reflect.Slice`
  via `sliceToValue`, with Kind set to `"array"`
- **Deserialization**: New `fromArrayValue` fills elements in-place — arrays
  are already sized so there's no `MakeSlice`/`Set` needed. If the data has
  fewer elements than the array, the rest stays zero-valued
- **JSON unmarshaling**: `fixTypes` handles `Array` kind the same as `Slice`
- Removed all TODO comments about array support
- Updated `ToValue` doc to no longer list arrays as unsupported

## Test plan

- [x] Serialize test: `&[3]int{10,20,30}` produces correct `Value` tree
- [x] Deserialize test: array `Value` tree round-trips back to `[3]int`
- [x] All existing tests pass (`go test -race ./...`)