### PR TITLE
Add generic Unmarshal[T] convenience wrapper

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -462,3 +462,13 @@ func FromValue(data *Value, v any) error {
 
 	return vu.fromValue(data, rv)
 }
+
+// Unmarshal is a type-safe generic wrapper around FromValue.
+// It allocates a new T, fills it from data, and returns a pointer to it.
+func Unmarshal[T any](data *Value) (*T, error) {
+	var result T
+	if err := FromValue(data, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/deserialize_test.go
+++ b/deserialize_test.go
@@ -528,3 +528,60 @@ func TestFromValue(t *testing.T) {
 		}
 	}
 }
+
+func TestUnmarshal(t *testing.T) {
+	// string
+	strData := &tahwil.Value{
+		Refid: 1,
+		Kind:  tahwil.Ptr,
+		Value: &tahwil.Value{
+			Refid: 2,
+			Kind:  tahwil.String,
+			Value: "hello",
+		},
+	}
+	s, err := tahwil.Unmarshal[string](strData)
+	if err != nil {
+		t.Fatalf("Unmarshal[string]: %v", err)
+	}
+	if *s != "hello" {
+		t.Errorf("Unmarshal[string] = %q, want %q", *s, "hello")
+	}
+
+	// struct
+	structData := &tahwil.Value{
+		Refid: 1,
+		Kind:  tahwil.Ptr,
+		Value: &tahwil.Value{
+			Refid: 2,
+			Kind:  tahwil.Struct,
+			Value: map[string]*tahwil.Value{
+				"name": {Refid: 3, Kind: tahwil.String, Value: "Alice"},
+				"parent": {Refid: 4, Kind: tahwil.Ptr, Value: nil},
+				"children": {Refid: 5, Kind: tahwil.Slice, Value: nil},
+			},
+		},
+	}
+	p, err := tahwil.Unmarshal[personT](structData)
+	if err != nil {
+		t.Fatalf("Unmarshal[personT]: %v", err)
+	}
+	if p.Name != "Alice" {
+		t.Errorf("Unmarshal[personT].Name = %q, want %q", p.Name, "Alice")
+	}
+
+	// error propagation
+	badData := &tahwil.Value{
+		Refid: 1,
+		Kind:  tahwil.Ptr,
+		Value: &tahwil.Value{
+			Refid: 2,
+			Kind:  tahwil.String,
+			Value: 42,
+		},
+	}
+	_, err = tahwil.Unmarshal[string](badData)
+	if err == nil {
+		t.Fatal("expected error from Unmarshal with bad data, got nil")
+	}
+}


### PR DESCRIPTION
`FromValue` requires callers to declare a variable, pass its address, and
then use the variable separately. A generic wrapper removes that ceremony:

```go
// before
var p personT
if err := tahwil.FromValue(data, &p); err != nil { ... }

// after
p, err := tahwil.Unmarshal[personT](data)
```

This is purely additive — `FromValue` stays as-is for cases where the
caller already has a destination value.

## Changes

- Add `Unmarshal[T any]` in `deserialize.go`
- Add `TestUnmarshal` covering string, struct, and error propagation

## Test plan

- [x] `TestUnmarshal` passes for string, struct, and error cases
- [x] All existing tests pass (`go test -race ./...`)